### PR TITLE
Check for index out of bound

### DIFF
--- a/src/grow.ml
+++ b/src/grow.ml
@@ -158,6 +158,7 @@ module Make (V : Varray_sig.TIER)
     end
 
   let pop_at t i =
+    if i >= length t then invalid_arg "pop_at";
     check_protection t ;
     decr_capacity t ;
     match i - V.length t.small with


### PR DESCRIPTION

Testing the library using Ortac/QCheck-STM (here](https://github.com/ocaml-gospel/ortac/pull/183) led to discovering that `Varray.Circular.delete_at` was not raising `Invalid_argument` on index out of bound like the documentation states and that `Varray.delete_at` segfaults.

This PR proposes to add a check for index out of bound in `Grow.Make.pop_at` as the least intrusive fix.